### PR TITLE
Yield from Around block even when local

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,24 +6,14 @@ require 'minitest'
 if ENV['local']
   Capybara.register_driver :selenium do |app|
     case ENV['browser']
-      when 'firefox' then Capybara::Selenium::Driver.new(app, browser: :firefox)
-      when 'safari'  then Capybara::Selenium::Driver.new(app, browser: :safari, :desired_capabilities => @safari_caps)
+      when 'firefox' Capybara::Selenium::Driver.new(app, browser: :firefox)
+      when 'safari' Capybara::Selenium::Driver.new(app, browser: :safari, :desired_capabilities => @safari_caps)
       # when 'iPhone'  then Capybara::Selenium::Driver.new(app, browser: :chrome, :desired_capabilities => @chrome_caps)
-      else Capybara::Selenium::Driver.new(app, browser: :chrome, :desired_capabilities => @chrome_caps)
+      else 
+        Capybara::Selenium::Driver.new(app, browser: :chrome, :desired_capabilities => @chrome_caps)
     end
   end
   Capybara.javascript_driver = :selenium
-
-else
-
-  require "sauce"
-  require "sauce/cucumber"
-  require "capybara"
-  require "sauce/capybara"
-
-  Capybara.default_driver = :sauce
-
 end
 
-
-
+## See sauce_helper.rb for non-Local test configuration

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,8 +6,8 @@ require 'minitest'
 if ENV['local']
   Capybara.register_driver :selenium do |app|
     case ENV['browser']
-      when 'firefox' Capybara::Selenium::Driver.new(app, browser: :firefox)
-      when 'safari' Capybara::Selenium::Driver.new(app, browser: :safari, :desired_capabilities => @safari_caps)
+      when 'firefox' then Capybara::Selenium::Driver.new(app, browser: :firefox)
+      when 'safari' then Capybara::Selenium::Driver.new(app, browser: :safari, :desired_capabilities => @safari_caps)
       # when 'iPhone'  then Capybara::Selenium::Driver.new(app, browser: :chrome, :desired_capabilities => @chrome_caps)
       else 
         Capybara::Selenium::Driver.new(app, browser: :chrome, :desired_capabilities => @chrome_caps)

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,16 +1,3 @@
-
-Around('@selenium') do |scenario, block|
-  unless ENV['local']
-    thread_id = Thread.current.object_id
-    caps = Sauce.driver_pool[thread_id].capabilities
-    ENV['SELENIUM_OS'] = /\w+/.match(caps[:platform]).to_s
-    ENV['SELENIUM_BROWSER'] = caps[:browser_name]
-    ENV['SELENIUM_VERSION'] = /\d+/.match(caps[:version]).to_s
-  end
-  
-  block.call
-end
-
 Before do
   Capybara.default_driver = :selenium
   Capybara.default_selector = :xpath
@@ -19,12 +6,16 @@ Before do
   ##########Setting flags##########
   @desktop = true unless ENV['browser'] == 'iPhone'
 
-  ##########Deleting prior screenshots if exists##########
-  Dir.glob('screenshot/*.png').each { |f| File.delete(f) } if ENV['local']
+  if ENV['local']
+    ##########Deleting prior screenshots if exists##########
+    Dir.glob('screenshot/*.png').each { |f| File.delete(f) }
 
-  @base_path_auth = "ask me"
-  @base_path = "ask me"
-  page.driver.browser.manage.window.resize_to(1280,1024) if @desktop
+    ####### Has to be wrapped in a local block, otherwise creates a local session
+    page.driver.browser.manage.window.resize_to(1280,1024) if @desktop
+  end
+
+  @base_path_auth = "http://www.google.com"
+  @base_path = "http://www.google.com"
 end
 
 After do |scenario|
@@ -34,4 +25,3 @@ After do |scenario|
     embed("./screenshot/#{scenario.__id__}.png", "image/png", "SCREENSHOT")
   end
 end
-

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -6,8 +6,9 @@ Around('@selenium') do |scenario, block|
     ENV['SELENIUM_OS'] = /\w+/.match(caps[:platform]).to_s
     ENV['SELENIUM_BROWSER'] = caps[:browser_name]
     ENV['SELENIUM_VERSION'] = /\d+/.match(caps[:version]).to_s
-    block.call
   end
+  
+  block.call
 end
 
 Before do

--- a/features/support/sauce_driver.rb
+++ b/features/support/sauce_driver.rb
@@ -1,14 +1,14 @@
-require "selenium/webdriver"
+# require "selenium/webdriver"
 
-module SauceDriver
-  class << self
-    def sauce_endpoint
-     "ask me"
-    end
+# module SauceDriver
+#   class << self
+#     def sauce_endpoint
+#      "ask me"
+#     end
 
-    def new_driver
-      Selenium::WebDriver.for :remote, :url => sauce_endpoint
-    end
-  end
-end
+#     def new_driver
+#       Selenium::WebDriver.for :remote, :url => sauce_endpoint
+#     end
+#   end
+# end
 

--- a/features/support/sauce_helper.rb
+++ b/features/support/sauce_helper.rb
@@ -1,41 +1,58 @@
-require "sauce"
-require "sauce/cucumber"
-require "capybara"
-require "sauce/capybara"
-require_relative "sauce_driver"
+unless ENV["local"]
+  require "sauce"
+  require "sauce/capybara"
+  require "sauce/cucumber"
 
-Sauce.config  do |config|
-  config[:browsers] = [
-      ["OS X 10.10","chrome","41"]
-      # ["Windows 10","chrome","41"],
-      # ["OS X 10.10","safari","8.0"]
-      # ["OS X 10.9","safari","7.0"],
-      # ["OS X 10.10","firefox","40"],
-      # ["Windows 10","firefox","40"]
-  ]
+  Capybara.default_driver = :sauce
+  Capybara.javascript_driver = :sauce
 
-  config['prerun'] = {
-    :executable =>'https://gist.githubusercontent.com/saucyallison/3a73a4e0736e556c990d/raw/d26b0195d48b404628fc12342cb97f1fc5ff58ec/disable_fraud.sh',
-    :background => 'false'
-  }
+  Sauce.config  do |config|
+    config[:browsers] = [
+        ["OS X 10.10","chrome","41"]
+        # ["Windows 10","chrome","41"],
+        # ["OS X 10.10","safari","8.0"]
+        # ["OS X 10.9","safari","7.0"],
+        # ["OS X 10.10","firefox","40"],
+        # ["Windows 10","firefox","40"]
+    ]
 
-  config.whitelist :screenResolution
-  config[:screenResolution] = "1280x1024"
-  config[:start_tunnel] = false
-  config.whitelist :autoAcceptAlerts
-  config[:autoAcceptAlerts] = true
-  config.whitelist :recordVideo
-  config[:recordVideo] = true
-  config.whitelist :recordScreenshots
-  config[:recordScreenshots] = true
-  config.whitelist :acceptSslCerts
-  config[:acceptSslCerts] = "true"
-  config.whitelist :avoidProxy
-  config[:avoidProxy] = "true"
-  config.whitelist :seleniumVersion
-  config[:seleniumVersion] =  "2.47.1"
+    config['prerun'] = {
+      :executable =>'https://gist.githubusercontent.com/saucyallison/3a73a4e0736e556c990d/raw/d26b0195d48b404628fc12342cb97f1fc5ff58ec/disable_fraud.sh',
+      :background => 'false'
+    }
 
+    config.whitelist :screenResolution
+    config[:screenResolution] = "1280x1024"
+    config[:start_tunnel] = false
+    config.whitelist :autoAcceptAlerts
+    config[:autoAcceptAlerts] = true
+    config.whitelist :recordVideo
+    config[:recordVideo] = true
+    config.whitelist :recordScreenshots
+    config[:recordScreenshots] = true
+    config.whitelist :acceptSslCerts
+    config[:acceptSslCerts] = "true"
+    config.whitelist :avoidProxy
+    config[:avoidProxy] = "true"
+    config.whitelist :seleniumVersion
+    config[:seleniumVersion] =  "2.47.1"
+
+  end
 end
 
+Around('@selenium') do |scenario, block|
+  unless ENV['local']
+    thread_id = Thread.current.object_id
+    driver = Sauce.driver_pool[thread_id]
+    caps = driver.capabilities
+    ENV['SELENIUM_OS'] = /\w+/.match(caps[:platform]).to_s
+    ENV['SELENIUM_BROWSER'] = caps[:browser_name]
+    ENV['SELENIUM_VERSION'] = /\d+/.match(caps[:version]).to_s
 
-
+    unless ENV['browser'] == 'iPhone'
+      driver.manage.window.resize_to(1280,1024)
+    end
+  end
+  
+  block.call
+end


### PR DESCRIPTION
Because Cuke was never yielding from the Around block when running locally, it was never executing anything.

Requiring Sauce conditionally prevents it from hijacking tests.

Moved the Around block because if it runs before the Sauce stuff is integrated, Nil reference errors occur.

Made setting the browser size conditional, because otherwise calling `page` makes Capybara spawn a new, local session.
